### PR TITLE
Add `encoding` parameter for non-ASCII characters

### DIFF
--- a/p2j/j2p.py
+++ b/p2j/j2p.py
@@ -3,7 +3,7 @@ import json
 from p2j.utils import _check_files
 
 
-def jupyter2python(source_filename: str, target_filename: str, overwrite: bool = False):
+def jupyter2python(source_filename: str, target_filename: str, overwrite: bool = False, encoding: str = "utf-8"):
     """Convert Jupyter notebooks to Python scripts
 
     Args:
@@ -11,6 +11,7 @@ def jupyter2python(source_filename: str, target_filename: str, overwrite: bool =
         target_filename (str): Path to name of Python script. Optional.
         overwrite (bool): Whether to overwrite an existing Python script.
         with_markdown (bool, optional): Whether to include markdown. Defaults to False.
+        encoding (str): Encodes obj using the codec registered for encoding.
     """
 
     target_filename = _check_files(
@@ -18,7 +19,7 @@ def jupyter2python(source_filename: str, target_filename: str, overwrite: bool =
 
     # Check if source file exists and read
     try:
-        with open(source_filename, "r", encoding="utf-8") as infile:
+        with open(source_filename, "r", encoding=encoding) as infile:
             myfile = json.load(infile)
     except FileNotFoundError:
         print("Source file not found. Specify a valid source file.")
@@ -30,6 +31,6 @@ def jupyter2python(source_filename: str, target_filename: str, overwrite: bool =
     final = "\n\n".join(final)
     final = final.replace("<br>", "")
 
-    with open(target_filename, "a", encoding="utf-8") as outfile:
+    with open(target_filename, "a", encoding=encoding) as outfile:
         outfile.write(final)
         print("Python script {} written.".format(target_filename))

--- a/p2j/main.py
+++ b/p2j/main.py
@@ -19,6 +19,11 @@ def main():
     parser.add_argument("-o", "--overwrite",
                         action="store_true",
                         help="Flag whether to overwrite existing target file.")
+    parser.add_argument("-e",
+                        "--encoding",
+                        default="utf-8",
+                        type=str,
+                        help="Encodes obj using the codec registered for encoding.")               
     args = parser.parse_args()
 
     if args.reverse:

--- a/p2j/p2j.py
+++ b/p2j/p2j.py
@@ -17,13 +17,14 @@ EIGHT_SPACES = "{:<8}".format("")
 TWELVE_SPACES = "{:<12}".format("")
 
 
-def python2jupyter(source_filename: str, target_filename: str, overwrite: bool = False):
+def python2jupyter(source_filename: str, target_filename: str, overwrite: bool = False, encoding: str = "utf-8"):
     """Convert Python scripts to Jupyter notebooks.
 
     Args:
         source_filename (str): Path to Python script.
         target_filename (str): Path to name of Jupyter notebook. Optional.
         overwrite (bool): Whether to overwrite an existing Jupyter notebook.
+        encoding (str): Encodes obj using the codec registered for encoding.
     """
 
     target_filename = _check_files(
@@ -31,18 +32,18 @@ def python2jupyter(source_filename: str, target_filename: str, overwrite: bool =
 
     # Check if source file exists and read
     try:
-        with open(source_filename, "r", encoding="utf-8") as infile:
+        with open(source_filename, "r", encoding=encoding) as infile:
             data = [l.rstrip("\n") for l in infile]
     except FileNotFoundError:
         print("Source file not found. Specify a valid source file.")
         sys.exit(1)
 
     # Read JSON files for .ipynb template
-    with open(HERE + "/templates/cell_code.json", encoding="utf-8") as file:
+    with open(HERE + "/templates/cell_code.json", encoding=encoding) as file:
         CODE = json.load(file)
-    with open(HERE + "/templates/cell_markdown.json", encoding="utf-8") as file:
+    with open(HERE + "/templates/cell_markdown.json", encoding=encoding) as file:
         MARKDOWN = json.load(file)
-    with open(HERE + "/templates/metadata.json", encoding="utf-8") as file:
+    with open(HERE + "/templates/metadata.json", encoding=encoding) as file:
         MISC = json.load(file)
 
     # Initialise variables
@@ -160,6 +161,6 @@ def python2jupyter(source_filename: str, target_filename: str, overwrite: bool =
     final.update(MISC)
 
     # Write JSON to target file
-    with open(target_filename, "w", encoding="utf-8") as outfile:
+    with open(target_filename, "w", encoding=encoding) as outfile:
         json.dump(final, outfile, indent=1, ensure_ascii=False)
         print("Notebook {} written.".format(target_filename))


### PR DESCRIPTION
## Description
Fixed the `UnicodeDecodeError` issue in `p2j` when processing Python scripts with Chinese comments. Added an encoding parameter (default=“utf-8”) to handle character encoding. Resolves Issue #16.

## Usage
Run code (OS is `windows 11`):
```python
p2j .\code.py -e "Big5" # Specify the desired encoding (e.g., Big5)
```

Expected output:
```
Notebook .\code.ipynb written.
```