### PR TITLE
Adding-function-call-to-cell

### DIFF
--- a/p2j/p2j.py
+++ b/p2j/p2j.py
@@ -135,6 +135,15 @@ def python2jupyter(source_filename: str, target_filename: str, overwrite: bool =
             # (next line is nothing AND next line is part of a function)
             if (is_end_of_code or next_is_nothing) and not (next_is_nothing and next_is_function):
                 arr.append("{}".format(buffer))
+
+                # Append the function call at the end of the each function
+                # This avoids efforts of writing statement of calling the function for every cell
+                fcall = arr[0].strip().lstrip("def ")
+                idx = fcall.find('(')
+                fcall = fcall[:idx]+'()'
+                arr.append("")
+                arr.append(fcall)
+
                 CODE["source"] = arr
                 cells.append(dict(CODE))
                 arr = []


### PR DESCRIPTION
Adding function call/invocation" in the same cell where function is defined

* Append the function call at the end of the each function
* This avoids efforts of writing statement of calling the function for every cell

* p2j behavior before and after for file 
* strings.py 
```python
def strings_printing_01(a=20, b=20):
    print("Hello world-1")
    print("Hello world-2")

def strings_printing_02() -> None:
    print("Hello world-1")
    print("Hello world-2")
```

**Before patch strings.ipynb**

```Python
def strings_printing_01(a=20, b=20):
    print("Hello world-1")
    print("Hello world-2")

def strings_printing_02() -> None:
    print("Hello world-1")
    print("Hello world-2")

```

**After patch strings.ipynb**
```python
def strings_printing_01(a=20, b=20):
    print("Hello world-1")
    print("Hello world-2")

strings_printing_01()

def strings_printing_02() -> None:
    print("Hello world-1")
    print("Hello world-2")

strings_printing_02()
```